### PR TITLE
fix(release)!: pause publishing domains/web (19.1 MiB vs a 10 MiB cap) + align README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 <p align="center">
+  <a href="https://pr4xis.dev"><img src="https://img.shields.io/badge/try_it-pr4xis.dev-1f6feb?logo=webassembly&logoColor=white" alt="Live demo: pr4xis.dev"/></a>
   <a href="https://crates.io/crates/pr4xis"><img src="https://img.shields.io/crates/v/pr4xis?logo=rust&logoColor=white" alt="crates.io"/></a>
   <a href="https://crates.io/crates/pr4xis"><img src="https://img.shields.io/crates/d/pr4xis?logo=rust&logoColor=white" alt="Downloads"/></a>
   <a href="https://docs.rs/pr4xis"><img src="https://img.shields.io/docsrs/pr4xis?logo=docsdotrs&logoColor=white" alt="docs.rs"/></a>
@@ -15,7 +16,6 @@
   <a href="https://nixos.org/"><img src="https://img.shields.io/badge/Nix-2b2b2b?logo=nixos&logoColor=white" alt="Nix"/></a>
   <a href="https://devenv.sh"><img src="https://img.shields.io/badge/devenv-2b2b2b?logo=nixos&logoColor=white" alt="devenv"/></a>
   <a href="https://webassembly.org/"><img src="https://img.shields.io/badge/WebAssembly-2b2b2b?logo=webassembly&logoColor=white" alt="WebAssembly"/></a>
-  <a href="https://pr4xis.dev"><img src="https://img.shields.io/badge/pr4xis.dev-2b2b2b?logo=firefoxbrowser&logoColor=white" alt="Live demo"/></a>
   <a href="https://doi.org/10.5281/zenodo.20755387"><img src="https://img.shields.io/badge/DOI-2b2b2b?logo=zenodo&logoColor=white" alt="DOI"/></a>
   <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img src="https://img.shields.io/badge/CC%20BY--NC--SA%204.0-2b2b2b?logo=creativecommons&logoColor=white" alt="License: CC BY-NC-SA 4.0"/></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
   <a href="https://crates.io/crates/pr4xis"><img src="https://img.shields.io/crates/v/pr4xis?logo=rust&logoColor=white" alt="crates.io"/></a>
   <a href="https://crates.io/crates/pr4xis"><img src="https://img.shields.io/crates/d/pr4xis?logo=rust&logoColor=white" alt="Downloads"/></a>
   <a href="https://docs.rs/pr4xis"><img src="https://img.shields.io/docsrs/pr4xis?logo=docsdotrs&logoColor=white" alt="docs.rs"/></a>
-  <a href="https://doi.org/10.5281/zenodo.20755387"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20755387.svg" alt="DOI"/></a>
-  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-2024-orange?logo=rust&logoColor=white" alt="Rust"/></a>
-  <a href="https://nixos.org/"><img src="https://img.shields.io/badge/built_with-nix-5277C3?logo=nixos&logoColor=white" alt="Built with Nix"/></a>
-  <a href="https://devenv.sh"><img src="https://img.shields.io/badge/devenv-2b2b2b?logo=nixos&logoColor=white" alt="devenv"/></a>
+  <a href="https://github.com/i-am-logger/pr4xis/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/i-am-logger/pr4xis/ci.yml?branch=master&label=CI&logo=githubactions&logoColor=white" alt="CI"/></a>
+  <a href="https://codecov.io/gh/i-am-logger/pr4xis"><img src="https://img.shields.io/codecov/c/github/i-am-logger/pr4xis?logo=codecov&logoColor=white" alt="Coverage"/></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/i-am-logger/pr4xis/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/i-am-logger/pr4xis/ci.yml?branch=master&label=CI&logo=githubactions&logoColor=white" alt="CI"/></a>
-  <a href="https://codecov.io/gh/i-am-logger/pr4xis"><img src="https://img.shields.io/codecov/c/github/i-am-logger/pr4xis?logo=codecov&logoColor=white" alt="Coverage"/></a>
-  <a href="https://scorecard.dev/viewer/?uri=github.com/i-am-logger/pr4xis"><img src="https://api.securityscorecards.dev/projects/github.com/i-am-logger/pr4xis/badge" alt="OpenSSF Scorecard"/></a>
-  <a href="https://pr4xis.dev"><img src="https://img.shields.io/badge/demo-pr4xis.dev-blue?logo=webassembly&logoColor=white" alt="Live Demo"/></a>
-  <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img src="https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg" alt="License"/></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust_2024-2b2b2b?logo=rust&logoColor=white" alt="Rust 2024"/></a>
+  <a href="https://nixos.org/"><img src="https://img.shields.io/badge/Nix-2b2b2b?logo=nixos&logoColor=white" alt="Nix"/></a>
+  <a href="https://devenv.sh"><img src="https://img.shields.io/badge/devenv-2b2b2b?logo=nixos&logoColor=white" alt="devenv"/></a>
+  <a href="https://webassembly.org/"><img src="https://img.shields.io/badge/WebAssembly-2b2b2b?logo=webassembly&logoColor=white" alt="WebAssembly"/></a>
+  <a href="https://pr4xis.dev"><img src="https://img.shields.io/badge/pr4xis.dev-2b2b2b?logo=firefoxbrowser&logoColor=white" alt="Live demo"/></a>
+  <a href="https://doi.org/10.5281/zenodo.20755387"><img src="https://img.shields.io/badge/DOI-2b2b2b?logo=zenodo&logoColor=white" alt="DOI"/></a>
+  <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img src="https://img.shields.io/badge/CC%20BY--NC--SA%204.0-2b2b2b?logo=creativecommons&logoColor=white" alt="License: CC BY-NC-SA 4.0"/></a>
 </p>
 
 # pr4xis — Axiomatic Intelligence

--- a/README.md
+++ b/README.md
@@ -3,19 +3,21 @@
 </p>
 
 <p align="center">
-  <a href="https://crates.io/crates/pr4xis"><img src="https://img.shields.io/crates/v/pr4xis.svg" alt="crates.io"/></a>
-  <a href="https://docs.rs/pr4xis-domains"><img src="https://docs.rs/pr4xis-domains/badge.svg" alt="docs.rs"/></a>
+  <a href="https://crates.io/crates/pr4xis"><img src="https://img.shields.io/crates/v/pr4xis?logo=rust&logoColor=white" alt="crates.io"/></a>
+  <a href="https://crates.io/crates/pr4xis"><img src="https://img.shields.io/crates/d/pr4xis?logo=rust&logoColor=white" alt="Downloads"/></a>
+  <a href="https://docs.rs/pr4xis"><img src="https://img.shields.io/docsrs/pr4xis?logo=docsdotrs&logoColor=white" alt="docs.rs"/></a>
   <a href="https://doi.org/10.5281/zenodo.20755387"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20755387.svg" alt="DOI"/></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-2024-orange?logo=rust&logoColor=white" alt="Rust"/></a>
   <a href="https://nixos.org/"><img src="https://img.shields.io/badge/built_with-nix-5277C3?logo=nixos&logoColor=white" alt="Built with Nix"/></a>
-  <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img src="https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg" alt="License"/></a>
+  <a href="https://devenv.sh"><img src="https://img.shields.io/badge/devenv-2b2b2b?logo=nixos&logoColor=white" alt="devenv"/></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/i-am-logger/pr4xis/actions/workflows/ci.yml"><img src="https://github.com/i-am-logger/pr4xis/actions/workflows/ci.yml/badge.svg?branch=master" alt="CI"/></a>
-  <a href="https://codecov.io/gh/i-am-logger/pr4xis"><img src="https://codecov.io/gh/i-am-logger/pr4xis/branch/master/graph/badge.svg" alt="Coverage"/></a>
+  <a href="https://github.com/i-am-logger/pr4xis/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/i-am-logger/pr4xis/ci.yml?branch=master&label=CI&logo=githubactions&logoColor=white" alt="CI"/></a>
+  <a href="https://codecov.io/gh/i-am-logger/pr4xis"><img src="https://img.shields.io/codecov/c/github/i-am-logger/pr4xis?logo=codecov&logoColor=white" alt="Coverage"/></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/i-am-logger/pr4xis"><img src="https://api.securityscorecards.dev/projects/github.com/i-am-logger/pr4xis/badge" alt="OpenSSF Scorecard"/></a>
-  <a href="https://pr4xis.dev"><img src="https://img.shields.io/badge/demo-pr4xis.dev-blue" alt="Live Demo"/></a>
+  <a href="https://pr4xis.dev"><img src="https://img.shields.io/badge/demo-pr4xis.dev-blue?logo=webassembly&logoColor=white" alt="Live Demo"/></a>
+  <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img src="https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg" alt="License"/></a>
 </p>
 
 # pr4xis — Axiomatic Intelligence

--- a/crates/domains/Cargo.toml
+++ b/crates/domains/Cargo.toml
@@ -46,23 +46,39 @@ include = [
     "data/**/*.prx.gz",
     "CHANGELOG.md",
 ]
-# NOTE: this crate is PUBLISHABLE and carries no `publish = false` (neither here
-# nor in release-plz.toml) — a manifest-level gate would make release-plz ignore
-# the crate outright (never versioned/tagged — the bug that stranded domains at
-# tag v0.21.0). The crates.io floor that used to block it — a build-time
-# `include_str!` of workspace files (`praxis.toml`, raw `data/*`) that fails
-# `cargo publish --verify` — is gone: the registered-source manifest and every
-# data source now ship as committed `.prx` (the `include` allowlist above), loaded
-# through the generalized registry gate, so `--verify` is clean.
+# NOTE: this crate carries no MANIFEST-level `publish = false`, deliberately — a
+# manifest-level gate would make release-plz ignore the crate outright (never
+# versioned/tagged, the bug that stranded domains at tag v0.21.0). Its publish is
+# PAUSED in release-plz.toml instead, which stops the upload while keeping the
+# versioning and tagging. Do not move that gate here.
 #
-# FIRST-PUBLISH BOOTSTRAP PENDING: this crate has release tags (v0.24.0..v0.25.4)
-# but was never on crates.io (it was `publish = false` until #219). A publishable
-# crate that is tagged-but-404 is the forbidden state that wedges release-plz's
-# Release-PR (see release-plz.toml + the `publish-invariant` CI job). It must be
-# first-published once, at 0.25.5, in workspace dependency order — `pr4xis`
-# (carrying the build-time codegen API `build.rs` calls, absent from the published
-# pr4xis 0.25.4) publishes before this crate. After that the invariant holds and
-# release-plz auto-bumps from here on.
+# The build-time floor that used to block publishing — an `include_str!` of
+# workspace files (`praxis.toml`, raw `data/*`) that failed `cargo publish
+# --verify` — is gone: every registered source ships as a committed `.prx`
+# through the allowlist above, so `--verify` is clean.
+#
+# What blocks it NOW is SIZE, and it is the allowlist's own doing. `data/**/*.prx`
+# is broader than the rationale above claims: of the 50 `.prx` it ships, only 40
+# are `include_bytes!`-embedded, and two of those are most of the weight —
+# conceptnet-5.7.0.prx (5.47 MB) and propbank-3.4.0.prx (3.75 MB). The package is
+# 19.1 MiB against crates.io's 10 MiB cap, and dropping every non-embedded file
+# still leaves 14.4 MiB. Unpausing means converting those two to runtime-loaded
+# registry sources like every other fetched corpus — a change to what this crate
+# guarantees is present, not a manifest edit.
+#
+# BEWARE THE SYMPTOM: crates.io rejects the oversized upload through its CDN as
+# an opaque HTTP 503, so this looks exactly like transient infrastructure. Three
+# consecutive publishes failed that way (v0.29.0, then v0.29.1 twice) before the
+# cause was measured with `cargo package`.
+#
+# The first-publish bootstrap this note used to describe is DONE: the crate
+# reached crates.io at 0.28.0, so it is no longer tagged-but-404 and the
+# forbidden state that wedged release-plz is behind us. crates.io now serves
+# 0.28.0 indefinitely while the repo moves on, which is a stale row rather than
+# an inconsistent one — `publish = false` in release-plz.toml exempts the crate
+# from the tag-vs-registry check, so nothing wedges.
+#
+# Unpausing needs BOTH: the package under 10 MiB, and a version past 0.28.0.
 
 [dependencies]
 # Runtime dep needs `std` only. The `codegen` feature (and its

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -109,6 +109,47 @@ commit_parsers = [
 # `pr4xis-examples` isn't either — they stay `publish = false` (no crates.io
 # value), which ALSO exempts them from the tag-vs-registry check; they share the
 # inherited version and are tagged + GitHub-released in lockstep.
+# `pr4xis-domains` PAUSED, and `pr4xis-web` with it — a size limit, not a policy
+# change. The crate packages at 19.1 MiB against crates.io's hard 10 MiB cap, so
+# the upload is rejected; crates.io surfaces that through its CDN as an opaque
+# HTTP 503, which is why three consecutive failed publishes (v0.29.0, then
+# v0.29.1 twice) read as transient infrastructure rather than what they were.
+#
+# It crossed the limit between 0.28.0 (published fine) and 0.29.0. The floor is
+# not reachable by trimming the `include` allowlist: only 10 of the 50 shipped
+# `.prx` are not `include_bytes!`-embedded, worth ~5.6 MB, and removing every one
+# of them still leaves 14.4 MiB. Two embedded files are most of the weight —
+# `data/conceptnet/conceptnet-5.7.0.prx` (5.47 MB) and
+# `data/propbank/propbank-3.4.0.prx` (3.75 MB) — so the real fix is converting
+# those to runtime-loaded registry sources like every other fetched corpus.
+# That is a change to the crate's contract, not a manifest tweak, and it is not
+# worth doing under a red master.
+#
+# `pr4xis-web` is paused only because it depends on `pr4xis-domains`: a
+# published crate cannot depend on a version that is not on crates.io.
+#
+# THIS IS THE RIGHT KNOB, and the distinction matters. `publish = false` HERE
+# exempts the crate from the tag-vs-registry check while release-plz still
+# versions, tags and GitHub-releases it in lockstep. `[package] publish = false`
+# in the crate's own Cargo.toml is the other thing entirely — it makes
+# release-plz ignore the crate outright, never versioning or tagging it, which
+# is the bug that stranded domains at tag v0.21.0. Do not "simplify" this by
+# moving it into the manifest.
+#
+# Consequence, stated plainly: crates.io keeps serving pr4xis-domains 0.28.0 and
+# pr4xis-web 0.28.0 while the repo moves on. Nothing consumes either — 54 and
+# 282 downloads, zero reverse dependencies — and `pr4xis` (510 downloads, 2
+# reverse deps), `pr4xis-derive` and `pr4xis-runtime` keep publishing normally,
+# so no consumer is affected. Unpausing requires the crate to be under 10 MiB
+# AND a version bump past 0.28.0; the publish-invariant job enforces the rest.
+[[package]]
+name = "pr4xis-domains"
+publish = false
+
+[[package]]
+name = "pr4xis-web"
+publish = false
+
 [[package]]
 name = "pr4xis-cli"
 publish = false


### PR DESCRIPTION
Two independent changes, both small and both touching only metadata/docs — no Rust, no CI logic.

## 1. Pause publishing `pr4xis-domains` and `pr4xis-web`

Master is red because `pr4xis-domains` cannot publish, and it is a **size limit**, not the transient infrastructure it looked like.

The crate packages at **19.1 MiB against crates.io's hard 10 MiB cap**, so the upload is rejected — and crates.io surfaces that through its CDN as an opaque **HTTP 503**. Three consecutive publishes failed identically (v0.29.0, then v0.29.1 twice, the last a deliberate retry) before the cause was measured with `cargo package` rather than inferred from the error.

It crossed the limit between 0.28.0, which published fine, and 0.29.0.

**Trimming the `include` allowlist cannot fix it.** Of the 50 `.prx` the crate ships, only 10 are not `include_bytes!`-embedded — worth ~5.6 MB — and removing every one still leaves **14.4 MiB**. Two embedded files are most of the weight:

| file | size |
|---|---|
| `data/conceptnet/conceptnet-5.7.0.prx` | 5.47 MB |
| `data/propbank/propbank-3.4.0.prx` | 3.75 MB |

Unpausing means converting those to runtime-loaded registry sources like every other fetched corpus — a change to what the crate guarantees is present, worth doing deliberately rather than under a red master.

`pr4xis-web` is paused only because it depends on `pr4xis-domains`: a published crate cannot depend on a version absent from crates.io.

### The gate goes in `release-plz.toml`, not the manifest

This distinction is the whole risk of the change. `publish = false` **there** exempts the crate from the tag-vs-registry check while release-plz still versions, tags and GitHub-releases it in lockstep. `[package] publish = false` in the crate's own `Cargo.toml` is a different thing entirely — it makes release-plz ignore the crate outright, never versioning or tagging it, which is the bug that stranded domains at tag v0.21.0.

Verified after the change:

```
cargo metadata → pr4xis-domains publish=true , pr4xis-web publish=true   (manifest level, unchanged)
publish-invariant exempt list → pr4xis-chat, -cli, -domains, -examples, -web
```

### Who is affected: nobody

| crate | downloads | reverse deps | status |
|---|---|---|---|
| `pr4xis-domains` | 54 | **0** | paused, crates.io keeps serving 0.28.0 |
| `pr4xis-web` | 282 | **0** | paused, same |
| `pr4xis` | 510 | **2** | unaffected, at 0.29.1 |
| `pr4xis-derive` / `pr4xis-runtime` | — | — | unaffected, at 0.29.1 |

crates.io keeps serving 0.28.0 of both — a stale row, not an inconsistent one, because the exemption removes them from the tag-vs-registry check.

### The caregiver demonstrator is unaffected, structurally

`crates/wasm` and `crates/web` depend on `pr4xis-domains` via `path = "../domains"`. `publish`/`include` only affect `cargo package`/`publish`, so the Pages build, the wasm bundle and every local build read the source tree directly. Checked too: the submission documents contain **zero** mentions of crates.io — no availability claim this could falsify.

Also corrects two now-false comments in `crates/domains/Cargo.toml`: the claim that the crate carries no `publish = false` anywhere, and a `FIRST-PUBLISH BOOTSTRAP PENDING` note describing work that completed at 0.28.0.

## 2. Align README badges with the `rav` convention

`rav` is the most evolved badge set of the three repos (`rust-template` has 3).

**Adopted:** a logo on every badge that has one (crates.io and docs.rs were bare); shields wrappers for CI and Coverage instead of GitHub's and codecov's native SVGs so everything renders in one visual system; `rav`'s ordering (identity → build → licence last); and the two missing badges, **Downloads** and **devenv**.

**Deliberately not copied:** `rav`'s badges are left-aligned plain markdown. praxis centres its logo *and* badges together, so a straight conversion would have discarded that — the `<p align="center">` wrapper stays, as do praxis's own DOI, OpenSSF Scorecard, Coverage and Live Demo badges.

**Not added:** an MSRV badge. `rav` has one, but it reads `rust-version` from crates.io and this workspace declares none, so it would render "unknown" permanently. Adding `rust-version` is a support-policy decision, not a README change.

**Fixed:** the docs.rs badge pointed at `pr4xis-domains` while crates.io pointed at `pr4xis`. Both now point at `pr4xis` — the crate with reverse dependencies.

Every URL was fetched and its **rendered text** read, not just its status code (shields returns 200 for invalid queries):

```
crates.io v0.29.1 · downloads 524 · docs passing · build failing · coverage unknown
```

Two of those are true and worth leaving visible. `build: failing` is accurate — master is red on the Release job, which this PR's first half addresses. `coverage: unknown` is also accurate and predates this change: the native codecov badge shows the same, because `coverage.yml` runs only on `release: published` and its single run was skipped.

## What to watch after merge

Pausing unblocks `Release`, but `Deploy Pages` fires only on `releases_created == 'true'`. If release-plz cuts a release with nothing left to publish, that output may come back `false` and Pages still will not deploy — the `workflow_dispatch` hatch (`deploy_pages: yes`) covers that case. Worth watching the first release run rather than assuming either way.
