### PR TITLE
fix(caregiver): assessment card leads the overview; three layout bugs

### DIFF
--- a/docs/chat/index.html
+++ b/docs/chat/index.html
@@ -488,16 +488,39 @@
             </ul>
           </div>
 
+          <!-- Post-submission third-party assessment, placed HIGH on the
+               overview deliberately: it is the one piece of evidence here not
+               authored by this project, so it belongs with the credibility
+               block (hero + sixty-seconds), not at the foot of the page.
+               Deliberately a separate card from anything labelled "Phase 1":
+               the five submission PDFs are frozen (emailed to ACL 2026-07-30)
+               and this letter arrived after them. Both quotes on this page
+               (here and on the Method view) are verbatim from the letter. -->
+          <div class="card quote-card">
+            <span class="card-title">Independent assessment</span>
+            <blockquote>“My professional judgment is that pr4xis is serious, carefully built work of a kind I do not often encounter. It addresses a real and widely acknowledged weakness in current artificial intelligence (that these systems cannot reliably tell you when they are wrong), and it does so with unusual rigour and intellectual honesty.”</blockquote>
+            <p class="quote-attr">— Alexander William Forrest Milton, President, tbay.tk LLC · 10 August 2026</p>
+            <p class="quote-context">From a professional assessment offered "freely and without compensation" by a software company that spent several months evaluating pr4xis for use in its own product. Received after the Phase 1 submission — shown beside the submitted record, not inside it.</p>
+            <div class="evidence-row">
+              <a class="btn btn-secondary" href="/caregiver-challenge/tbay-assessment-letter.pdf">Read the full letter (PDF)</a>
+            </div>
+          </div>
+
           <div class="progress" id="boot" style="max-width:32rem;">
             <div class="progress-head"><span class="progress-phase" id="boot-phase">Starting worker…</span><span class="note" id="boot-detail"></span></div>
             <div class="progress-track"><div class="progress-fill indeterminate" id="boot-fill"></div></div>
-            <!-- Said before the download starts rather than discovered during
-                 it. The whole engine arrives once and the device answers on
-                 its own afterwards; on a metered connection that is the
-                 reader's call, so the page gives them what they need to make
-                 it. The live figures below come from the transfer itself. -->
-            <div class="note" style="margin-top:0.5rem;">The engine downloads once — about 22&nbsp;MB, near 19&nbsp;MB over the wire compressed — and is then cached by your browser. Once it is answering, it also fetches the statutory text it reasons over in the background: six citation and provenance vocabularies (under 1&nbsp;MB together) and Title&nbsp;42 of the U.S. Code, about 35&nbsp;MB, which carries Medicare, Medicaid, the Older Americans Act and the HCBS waiver authorities. You can ask questions throughout; more becomes answerable as each arrives, and the source panel shows exactly what has landed. After that it answers with no network at all, and no question you type leaves this device.</div>
           </div>
+          <!-- Said before the download starts rather than discovered during
+               it. The whole engine arrives once and the device answers on
+               its own afterwards; on a metered connection that is the
+               reader's call, so the page gives them what they need to make
+               it. The live figures come from the transfer itself.
+
+               OUTSIDE #boot on purpose: the 32rem cap on the progress bar is
+               right for a progress bar and wrong for a paragraph — nested
+               inside, this text rendered as a ~500px column on a full-width
+               page. The bar keeps its cap; the prose fills the view. -->
+          <div class="note">The engine downloads once — about 22&nbsp;MB, near 19&nbsp;MB over the wire compressed — and is then cached by your browser. Once it is answering, it also fetches the statutory text it reasons over in the background: six citation and provenance vocabularies (under 1&nbsp;MB together) and Title&nbsp;42 of the U.S. Code, about 35&nbsp;MB, which carries Medicare, Medicaid, the Older Americans Act and the HCBS waiver authorities. You can ask questions throughout; more becomes answerable as each arrives, and the source panel shows exactly what has landed. After that it answers with no network at all, and no question you type leaves this device.</div>
 
           <div class="tiles" id="hero-tiles">
             <div class="tile"><div class="value na" id="t-concepts">—</div><div class="label">concepts loaded</div></div>
@@ -535,22 +558,6 @@
             <a href="#caregiver/method">Partnerships</a>
           </nav>
 
-          <!-- Post-submission third-party assessment. Deliberately a separate
-               card from anything labelled "Phase 1": the five submission PDFs
-               are frozen (emailed to ACL 2026-07-30) and this letter arrived
-               after them, so the page keeps that boundary visible instead of
-               folding new evidence into the submitted record. Both quotes on
-               this page (here and on the Method view) are verbatim from the
-               letter. -->
-          <div class="card">
-            <span class="card-title">Independent assessment</span>
-            <p class="note">Received after the Phase 1 submission: a professional assessment from the president of a software company that spent several months evaluating pr4xis for use in its own product — offered, in his words, "freely and without compensation".</p>
-            <p>“My professional judgment is that pr4xis is serious, carefully built work of a kind I do not often encounter. It addresses a real and widely acknowledged weakness in current artificial intelligence (that these systems cannot reliably tell you when they are wrong), and it does so with unusual rigour and intellectual honesty.”</p>
-            <p class="note">— Alexander William Forrest Milton, President, tbay.tk LLC · 10 August 2026</p>
-            <div class="evidence-row">
-              <a class="btn btn-secondary" href="/caregiver-challenge/tbay-assessment-letter.pdf">Read the full letter (PDF)</a>
-            </div>
-          </div>
         </main>
 
         <!-- ==================== TRACK WORKSPACES (generic 4-column layout) ==================== -->
@@ -724,11 +731,11 @@
                is the one that names the challenge's own two domains — medical
                decision support and regulatory compliance. Verbatim from the
                letter, as is the headline quote on the Overview. -->
-          <div class="card">
+          <div class="card quote-card">
             <span class="card-title">Independent assessment</span>
-            <p class="note">Received after the Phase 1 submission: a professional assessment from the president of a software company that spent several months evaluating pr4xis for use in its own product — offered, in his words, "freely and without compensation".</p>
-            <p>“It is well suited to any setting where an answer must be defensible rather than merely plausible: aerospace and vehicle autonomy, medical decision support, industrial safety, regulatory compliance, and the checking of work produced by other AI systems.”</p>
-            <p class="note">— Alexander William Forrest Milton, President, tbay.tk LLC · 10 August 2026</p>
+            <blockquote>“It is well suited to any setting where an answer must be defensible rather than merely plausible: aerospace and vehicle autonomy, medical decision support, industrial safety, regulatory compliance, and the checking of work produced by other AI systems.”</blockquote>
+            <p class="quote-attr">— Alexander William Forrest Milton, President, tbay.tk LLC · 10 August 2026</p>
+            <p class="quote-context">From a professional assessment offered "freely and without compensation" by a software company that spent several months evaluating pr4xis for use in its own product. Received after the Phase 1 submission — shown beside the submitted record, not inside it.</p>
             <div class="evidence-row">
               <a class="btn btn-secondary" href="/caregiver-challenge/tbay-assessment-letter.pdf">Read the full letter (PDF)</a>
             </div>

--- a/docs/chat/tokens.css
+++ b/docs/chat/tokens.css
@@ -293,6 +293,28 @@ button, .btn, a.btn, input, select, [role="tab"] { min-height: var(--tap); }
    makes the qualifier shout as loudly as the title it qualifies. */
 .card-title .note { font-weight: 400; font-size: var(--fs-small); color: var(--muted); }
 
+/* ================= independent-assessment pull quote ================= */
+/* The tbay.tk assessment cards (Overview + Method). The first rendering set
+   the quote as plain body paragraphs, visually identical to every other card
+   — an endorsement that reads like boilerplate. This gives it a real
+   pull-quote shape: the quote leads, italic and bright, behind the same blue
+   left accent `.summary-box` carries, and attribution then provenance step
+   down in size so the eye order is quote → who → context. Margins are 0
+   because `.card` is a flex column whose `gap` owns the vertical rhythm. */
+.quote-card { border-left: 3px solid var(--base0D); }
+.quote-card blockquote {
+  margin: 0; font-style: italic; font-size: 1.08em; line-height: 1.6;
+  color: var(--text-bright);
+}
+.quote-card .quote-attr { margin: 0; color: var(--text); font-size: var(--fs-small); }
+.quote-card .quote-context { margin: 0; color: var(--muted); font-size: var(--fs-small); }
+
+/* Rows of document buttons (the Phase 1 evidence card, the assessment cards).
+   This class shipped with NO rule at all, so the buttons packed edge to edge —
+   the "boxes without gaps". Flex + gap + wrap matches every other row on the
+   page and keeps the buttons usable at narrow widths. */
+.evidence-row { display: flex; flex-wrap: wrap; gap: var(--sp-2); }
+
 /* ============================ tag ============================ */
 .tag {
   display: inline-block; padding: 0.1rem 0.5rem; border-radius: 5px;
@@ -515,7 +537,10 @@ button, .btn, a.btn, input, select, [role="tab"] { min-height: var(--tap); }
 .view.active { display: flex; }
 .view-head { display: flex; flex-direction: column; gap: var(--sp-1); }
 .view-head h2 { font-size: var(--fs-h1); }
-.view-head .view-lede { color: var(--muted); max-width: 68ch; }
+/* No measure cap: at the view's 90rem width a 68ch cap rendered every lede as
+   a ~500px column beside an empty half-page — it read as a layout bug, not a
+   typographic choice. The lede fills the view like the content below it. */
+.view-head .view-lede { color: var(--muted); }
 
 /* ============================ case workflow (4-col guided verification) ============================ */
 .case-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr)); gap: var(--sp-4); align-items: start; }


### PR DESCRIPTION
The first rendering of the assessment card was reviewed on the live site and read as an afterthought — parked at the foot of the Overview, quote set as plain paragraphs. Fixed, plus two page-wide layout bugs the same review surfaced.

## Card placement + shape

- Moved from the foot of the Overview to **directly under the sixty-seconds box** — it's the one piece of evidence on the page not authored by this project, so it belongs with the credibility block, not after the navigation cards.
- Both cards (Overview + Method) are now real **pull quotes** via a small `.quote-card` treatment: quote leads, italic and bright, behind the same blue left accent `.summary-box` carries; attribution and provenance step down so the eye order is quote → who → context. Semantic `<blockquote>`.

## The 50%-width text — two distinct causes

- `.view-lede` carried `max-width: 68ch`, which inside a 90rem view rendered every lead paragraph as a **~500px column beside an empty half page**. Cap removed.
- The engine-download paragraph was **nested inside `#boot`**, inheriting its `max-width: 32rem` — right for a progress bar, absurd for a nine-line paragraph. Moved outside; the bar keeps its cap. Text unchanged, confirmed by the DOM contract's boot-disclosure checks.

## The gapless button rows

`.evidence-row` shipped with **no CSS rule at all**, so the five Phase 1 PDF buttons packed edge to edge. Now flex + wrap + gap.

## Verified by looking

Headless-Firefox screenshots of `#caregiver` and `#caregiver/method` — the step whose omission caused this round. Overview: card high with the styled quote, both long paragraphs fill the width. Method: five buttons properly gapped, assessment card beside (not inside) the Phase 1 card.

Gates: dom-contract (18 checks), program-ladder, abstain-load-gate, palette_wcag — all pass.

After merge: dispatch deploy (`deploy_pages: yes`) to update pr4xis.dev.